### PR TITLE
Create a new applicant record if one doesn't exist yet

### DIFF
--- a/src/store/applicant.js
+++ b/src/store/applicant.js
@@ -17,8 +17,13 @@ const module = {
         throw new Error('Cannot get Applicant doc (currentUserId is not set)');
       }
       const snapshot = await getters.applicantDoc.get();
-      const data = sanitizeFirestore(snapshot.data());
-      commit('setApplicant', data);
+
+      if (snapshot.exists) {
+        const data = sanitizeFirestore(snapshot.data());
+        commit('setApplicant', data);
+      } else {
+        commit('setApplicant', {});
+      }
     },
     async saveApplicant({commit, getters}, data) {
       if (!getters.applicantDoc) {

--- a/tests/unit/store/applicant.spec.js
+++ b/tests/unit/store/applicant.spec.js
@@ -55,7 +55,7 @@ describe('store/applicant', () => {
         });
       });
 
-      describe('happy path', () => {
+      describe('applicant exists in Firestore', () => {
         const docId = '4jsbvO27RJYqSRsgZM9sPhDFLDU2';
         const data = {name: 'John Smith'};
         const sanitizedData = {name: 'John Smith', sanitized: true};
@@ -76,6 +76,19 @@ describe('store/applicant', () => {
 
         it('commits the sanitized data', () => {
           expect(context.commit).toHaveBeenCalledWith('setApplicant', sanitizedData);
+        });
+      });
+
+      describe('applicant does not exist in Firestore - initialise an empty state', () => {
+        const docId = '4jsbvO27RJYqSRsgZM9sPhDFLDU2';
+
+        beforeEach(async () => {
+          getters.applicantDoc = firestore.collection('applicants').doc(docId);
+          await actions.loadApplicant(context);
+        });
+
+        it('commits an empty data object', () => {
+          expect(context.commit).toHaveBeenCalledWith('setApplicant', {});
         });
       });
 


### PR DESCRIPTION
This commit resolves a bug where the Application Form would throw unhandled exceptions if the user's `applicant` record didn't exist in Firestore. This resulted in the store data type becoming `undefined` rather than the expected `object`, consequently breaking the application. Instead, an empty object is used as the state, which upon dispatching `saveApplicant` will create the document in Firestore.

A unit test has been added to cover this case.