### PR TITLE
Fix Vue warnings related to `SelectList` component

### DIFF
--- a/src/components/SelectList.vue
+++ b/src/components/SelectList.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div :class="divClass" v-for="(option, index) in inputOptions" :key="option">
+    <div :class="divClass" v-for="(option, index) in inputOptions" :key="option.value">
       <input class="custom-control-input" :type="type" :id="id + '_' + index" :value="option.value" v-model="inputValue">
       <label class="custom-control-label" :for="id + '_' + index">
         {{option.label}}

--- a/src/views/FormSections/Nationality.vue
+++ b/src/views/FormSections/Nationality.vue
@@ -5,7 +5,7 @@
 
       <fieldset>
         <legend>What’s your nationality?</legend>
-        <SelectList :options="nationalityOptions" v-model="applicant.nationality" />
+        <SelectList id="nationality" :options="nationalityOptions" v-model="applicant.nationality" />
         <div v-if="applicant.nationality === 'Non-Commonwealth'" class="mt-3">
           Email <a href="mailto:dcj128@judicialappointments.gov.uk">dcj128@judicialappointments.gov.uk</a> or
           call <a href="tel:+442033340123">020 3334 0123</a> to discuss your application


### PR DESCRIPTION
This commit fixed two Vue warnings related to the `SelectList` component.

Firstly, it resolves an issue where `v-for` with `key` attribute was incorrectly implemented. This was because the `key` attribute needed to be changed when `SelectList`'s internal data structure was changed to support values independent from their labels. The `key` attribute should always be given a string or number, whereas it was being given an object which caused the warning.

Secondly, a missing `id` attribute was added to the `SelectList` used on the Nationality page. `SelectList` always requires an `id` attribute, and throws warnings without it.