### PR TITLE
Add a new `BooleanInput` component

### DIFF
--- a/src/components/BooleanInput.vue
+++ b/src/components/BooleanInput.vue
@@ -1,0 +1,44 @@
+<template>
+  <div>
+    <div class="custom-control custom-radio custom-control-inline">
+      <input class="custom-control-input" type="radio" :id="yesInputId" :value="true" v-model="inputValue">
+      <label class="custom-control-label" :for="yesInputId">Yes</label>
+    </div>
+    <div class="custom-control custom-radio custom-control-inline">
+      <input class="custom-control-input" type="radio" :id="noInputId" :value="false" v-model="inputValue">
+      <label class="custom-control-label" :for="noInputId">No</label>
+    </div>
+  </div>
+</template>
+
+<script>
+  let uid = 0;
+
+  export default {
+    name: 'BooleanInput',
+    props: {
+      value: {
+        required: true,
+      },
+    },
+    data() {
+      return {
+        yesInputId: `boolean_${uid}_yes`,
+        noInputId: `boolean_${uid}_no`,
+      };
+    },
+    computed: {
+      inputValue: {
+        get() {
+          return this.value;
+        },
+        set(value) {
+          this.$emit('input', value);
+        }
+      },
+    },
+    created() {
+      uid++;
+    }
+  }
+</script>


### PR DESCRIPTION
Closes #21
Connect #21

This component repeats the common 'yes/no' radio input pattern which is used throughout the form. It's typically used in conjunction with a question, for example:

Do you need any reasonable adjustments?
[radio inputs]
○ Yes    ○ No

Bound to a data model with `v-model`, it will return a JavaScript boolean `true` or `false` given a 'Yes' or 'No' answer respectively.

### Example usage

```vue
<template>
  <fieldset>
    <legend>Do you have any criminal convictions?</legend>
    <BooleanInput v-model="has_criminal_conviction" />
  </fieldset>
</template>
```

---

**Note:** This implements the component discussed in #21, but does not add unit tests so that ticket will not be 'done' after this PR is merged. Unit tests on this component will follow later – this PR is to aid rapidly implementing our end-to-end journey.