### PR TITLE
Add new `RepeatableFields` component

### DIFF
--- a/src/components/RepeatableFields.vue
+++ b/src/components/RepeatableFields.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <div class="card mb-3" v-for="(row, index) in rows" :key="index">
+      <component class="card-body" :row="row" :index="index" :is="component">
+        <template slot="removeButton">
+          <button @click.prevent="removeRow(index)" class="btn btn-secondary">
+            Remove
+          </button>
+        </template>
+      </component>
+    </div>
+    <div class="text-right">
+      <button @click.prevent="addRow" class="btn btn-primary">
+        Add another
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+  export default {
+    name: 'RepeatableFields',
+    props: {
+      value: {
+        type: Array,
+        required: true,
+      },
+      component: {
+        required: true,
+      },
+    },
+    methods: {
+      addRow() {
+        this.rows.push({});
+      },
+      removeRow(index) {
+        this.rows.splice(index, 1);
+      },
+    },
+    computed: {
+      rows: {
+        get() {
+          return this.value;
+        },
+        set(value) {
+          this.$emit('input', value);
+        }
+      }
+    },
+    created() {
+      if (this.rows.length === 0) {
+        this.addRow();
+      }
+    }
+  }
+</script>


### PR DESCRIPTION
This PR adds a new `RepeatableFields` component. The component can be used to produce dynamically repeatable fields, which is a common pattern used throughout the application form fields.

For example, it could be used to allow users to enter a list of qualifications. It includes 'Add another' and 'Remove' buttons to allow users to add to the list and remove existing items from the list.

For each row of data, it will render a sub-component specified by the `component` attribute. That rendered component will receive two properties, `row` and `index`, allowing the component to edit the data for that row.

The sub-component will need to render the 'Remove' button, which is available via the 'removeButton' slot.