### PR TITLE
Delete functions not in index.js automatically

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ script:
 after_success:
   - test $TRAVIS_BRANCH = "master" &&
     test $TRAVIS_PULL_REQUEST = "false" &&
-    firebase deploy --token $FIREBASE_TOKEN --project default
+    firebase deploy --token $FIREBASE_TOKEN --project default --force


### PR DESCRIPTION
Without `--force` travis will hang if there are experimental functions
deployed that are not in index.js.