### PR TITLE
Month input capability for `DateInput` component

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="form-row mb-3">
-    <div class="col-3">
+    <div class="col-3" v-if="type === 'date'">
       <label :for="dayInputId">Day</label>
       <input type="number" min="1" max="31" class="form-control" :id="dayInputId" v-model.lazy="dayInput" ref="dayInput">
     </div>
@@ -24,6 +24,10 @@
       value: {
         required: true,
         validator: (value) => (value instanceof Date || value === null || value === undefined),
+      },
+      type: {
+        default: 'date',
+        validator: (value) => (['date', 'month'].indexOf(value) !== -1),
       },
     },
     data() {
@@ -97,7 +101,9 @@
         const month = this.month;
         const year = this.year;
 
-        if (day && month && year) {
+        if (this.type === 'month' && month && year) {
+          return [year, month-1];
+        } else if (day && month && year) {
           return [year, month-1, day];
         } else {
           return null;

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="form-row mb-3">
+  <div class="date-input form-row mb-3">
     <div class="col-3" v-if="type === 'date'">
       <label :for="dayInputId">Day</label>
       <input type="number" min="1" max="31" class="form-control" :id="dayInputId" v-model.lazy="dayInput" ref="dayInput">
@@ -155,6 +155,8 @@
   }
 </script>
 
-<style scoped>
-
+<style>
+  .date-input {
+    max-width: 18rem;
+  }
 </style>

--- a/src/views/FormSections/Personal.vue
+++ b/src/views/FormSections/Personal.vue
@@ -23,7 +23,7 @@
         <div class="fieldset-text">
           For example, 31 03 1980
         </div>
-        <DateInput v-model="applicant.date_of_birth" style="max-width: 18rem;" />
+        <DateInput v-model="applicant.date_of_birth" />
       </fieldset>
 
       <fieldset>

--- a/src/views/FormSections/Qualifications.vue
+++ b/src/views/FormSections/Qualifications.vue
@@ -22,7 +22,7 @@
         <fieldset>
           <legend>When were you admitted as a solicitor?</legend>
           <div class="fieldset-text">For example, 02 2017</div>
-          <DateInput v-model="applicant.solicitor_date_admitted" style="max-width: 18rem;" />
+          <DateInput v-model="applicant.solicitor_date_admitted" />
         </fieldset>
 
         <fieldset>
@@ -35,7 +35,7 @@
         <fieldset>
           <legend>When were you called to the Faculty?</legend>
           <div class="fieldset-text">For example, 02 2017</div>
-          <DateInput v-model="applicant.advocate_date_called_to_faculty" style="max-width: 18rem;" />
+          <DateInput v-model="applicant.advocate_date_called_to_faculty" />
         </fieldset>
       </div>
 
@@ -43,7 +43,7 @@
         <fieldset>
           <legend>When were you called to the Bar?</legend>
           <div class="fieldset-text">For example, 02 2017</div>
-          <DateInput v-model="applicant.barrister_date_called_to_bar" style="max-width: 18rem;" />
+          <DateInput v-model="applicant.barrister_date_called_to_bar" />
         </fieldset>
 
         <div v-if="applicant.location_qualified !== 'Northern Ireland'">
@@ -55,7 +55,7 @@
             <div v-if="applicant.barrister_completed_pupillage" class="mt-3">
               <p>When did you complete pupillage?</p>
               <div class="fieldset-text">For example, 02 2017</div>
-              <DateInput v-model="applicant.barrister_date_completed_pupillage" style="max-width: 18rem;" />
+              <DateInput v-model="applicant.barrister_date_completed_pupillage" />
             </div>
 
             <div v-if="!applicant.barrister_completed_pupillage" class="mt-3">

--- a/src/views/FormSections/Qualifications.vue
+++ b/src/views/FormSections/Qualifications.vue
@@ -22,7 +22,7 @@
         <fieldset>
           <legend>When were you admitted as a solicitor?</legend>
           <div class="fieldset-text">For example, 02 2017</div>
-          <DateInput v-model="applicant.solicitor_date_admitted" />
+          <DateInput v-model="applicant.solicitor_date_admitted" type="month" />
         </fieldset>
 
         <fieldset>
@@ -35,7 +35,7 @@
         <fieldset>
           <legend>When were you called to the Faculty?</legend>
           <div class="fieldset-text">For example, 02 2017</div>
-          <DateInput v-model="applicant.advocate_date_called_to_faculty" />
+          <DateInput v-model="applicant.advocate_date_called_to_faculty" type="month" />
         </fieldset>
       </div>
 
@@ -43,7 +43,7 @@
         <fieldset>
           <legend>When were you called to the Bar?</legend>
           <div class="fieldset-text">For example, 02 2017</div>
-          <DateInput v-model="applicant.barrister_date_called_to_bar" />
+          <DateInput v-model="applicant.barrister_date_called_to_bar" type="month" />
         </fieldset>
 
         <div v-if="applicant.location_qualified !== 'Northern Ireland'">
@@ -55,7 +55,7 @@
             <div v-if="applicant.barrister_completed_pupillage" class="mt-3">
               <p>When did you complete pupillage?</p>
               <div class="fieldset-text">For example, 02 2017</div>
-              <DateInput v-model="applicant.barrister_date_completed_pupillage" />
+              <DateInput v-model="applicant.barrister_date_completed_pupillage" type="month" />
             </div>
 
             <div v-if="!applicant.barrister_completed_pupillage" class="mt-3">

--- a/src/views/RepeatableFields/Qualification.vue
+++ b/src/views/RepeatableFields/Qualification.vue
@@ -10,7 +10,10 @@
     </div>
     <div class="form-group">
       <label>Qualification date</label>
-      <DateInput v-model="row.date" />
+      <div class="fieldset-text">
+        For example, 02 2017
+      </div>
+      <DateInput v-model="row.date" type="month" />
     </div>
     <slot name="removeButton"></slot>
   </div>

--- a/src/views/RepeatableFields/Qualification.vue
+++ b/src/views/RepeatableFields/Qualification.vue
@@ -10,7 +10,7 @@
     </div>
     <div class="form-group">
       <label>Qualification date</label>
-      <DateInput v-model="row.date" style="max-width: 18rem;" />
+      <DateInput v-model="row.date" />
     </div>
     <slot name="removeButton"></slot>
   </div>


### PR DESCRIPTION
Closes #32

This PR adds support for month/year inputs provided by the `<DateInput>` component.

### Tech Debt

This PR also clears up some tech debt:

- Sets a `max-width` CSS rule for all `<DateInput>` instances. This means we've been able to remove numerous `style="max-width:..."` rules from throughout the codebase.
- Updates the Qualifications date input fields to be month/year inputs, as required by the ticket. These were previously day/month/year inputs because they were developed prior to this PR.

### Usage

#### Day / Month / Year input

For a regular day/month/year input:

```vue
<DateInput v-model="example" />
<!-- which is the same as -->
<DateInput v-model="example" type="date" />
```

Renders:

<img width="285" alt="application-form" src="https://user-images.githubusercontent.com/7735945/53744771-95747f80-3e95-11e9-9bae-0b47e1cea262.png">

#### Month / Year input

For a month/year input:

```vue
<DateInput v-model="example" type="month" />
```

Renders:

<img width="213" alt="application-form" src="https://user-images.githubusercontent.com/7735945/53744849-c0f76a00-3e95-11e9-9a14-77e75ae6b67b.png">
