### PR TITLE
Fix an IE11 bug which stopped the page from rendering

### DIFF
--- a/src/components/SelectList.vue
+++ b/src/components/SelectList.vue
@@ -1,7 +1,15 @@
 <template>
   <div>
     <div :class="divClass" v-for="(option, index) in inputOptions" :key="option.value">
-      <input class="custom-control-input" :type="type" :id="id + '_' + index" :value="option.value" v-model="inputValue">
+      <!--
+        Dynamic `type` attributes don't work in IE11, so here we conditionally show/hide a radio or checkbox
+        depending on the value of the `type` computed property.
+
+        Related to: https://github.com/vuejs/vue/issues/8379
+      -->
+      <input v-if="type === 'radio'" type="radio" class="custom-control-input" :id="id + '_' + index" :value="option.value" v-model="inputValue">
+      <input v-if="type === 'checkbox'" type="checkbox" class="custom-control-input" :id="id + '_' + index" :value="option.value" v-model="inputValue">
+
       <label class="custom-control-label" :for="id + '_' + index">
         {{option.label}}
       </label>


### PR DESCRIPTION
This PR fixes #36 – an IE11 bug which caused a 'white screen of death' as the page failed to render.

The cause of this bug is discussed in vuejs/vue#8379. To summarise: the use of dynamically bound `type` attributes on `<input>` elements compiles into bad JS output, which chokes IE11.

Dynamic `type` binding was used in the `SelectList` component to render either a radio or checkbox input (depending on the value of the `multiple` property). To work around this limitation, I've split both potential input types (a radio input and a checkbox input) into their own elements, and conditionally show/hide them with `v-if`. This produces different JS output which keeps IE11 happy.