### PR TITLE
Fix a bug in the `application` Vuex module

### DIFF
--- a/src/store/application.js
+++ b/src/store/application.js
@@ -8,7 +8,7 @@ const module = {
     id: null,
   },
   mutations: {
-    setApplication(state, id, data) {
+    setApplication(state, {id, data}) {
       state.id = id;
       state.data = data;
     },
@@ -27,7 +27,7 @@ const module = {
         .get();
 
       if (results.empty) {
-        commit('setApplication', null, {});
+        commit('setApplication', {id: null, data: {}});
       } else {
         const doc = results.docs[0];
 
@@ -36,7 +36,7 @@ const module = {
         delete data.vacancy;
         data = sanitizeFirestore(data);
 
-        commit('setApplication', doc.id, data);
+        commit('setApplication', {id: doc.id, data});
       }
     },
     async saveApplication({commit, getters}, data) {
@@ -47,7 +47,7 @@ const module = {
       saveData.applicant = getters.applicantDoc;
       saveData.vacancy = getters.vacancyDoc;
       await getters.applicationDoc.set(saveData);
-      commit('setApplication', getters.applicationDoc.id, clone(data));
+      commit('setApplication', {id: getters.applicationDoc.id, data: clone(data)});
     },
   },
   getters: {

--- a/tests/unit/store/application.spec.js
+++ b/tests/unit/store/application.spec.js
@@ -28,7 +28,7 @@ describe('store/application', () => {
       const data = {status: 'draft'};
 
       beforeEach(() => {
-        mutations.setApplication(state, id, data);
+        mutations.setApplication(state, {id, data});
       });
 
       it('stores the supplied document ID in the state', () => {
@@ -86,7 +86,7 @@ describe('store/application', () => {
         });
 
         it('commits the document ID and sanitized data', () => {
-          expect(context.commit).toHaveBeenCalledWith('setApplication', docId, sanitizedData);
+          expect(context.commit).toHaveBeenCalledWith('setApplication', {id: docId, data: sanitizedData});
         });
       });
 
@@ -103,7 +103,7 @@ describe('store/application', () => {
         });
 
         it('commits a null document ID and an empty data object', () => {
-          expect(context.commit).toHaveBeenCalledWith('setApplication', null, {});
+          expect(context.commit).toHaveBeenCalledWith('setApplication', {id: null, data: {}});
         });
       });
 
@@ -163,8 +163,8 @@ describe('store/application', () => {
         it('commits the document ID and a copy of the data (not the input object passed by reference)', async () => {
           const data = {status: 'submitted'};
           await actions.saveApplication(context, data);
-          expect(context.commit).toHaveBeenCalledWith('setApplication', 'abc123', data);
-          const committedData = context.commit.mock.calls[0][2];
+          expect(context.commit).toHaveBeenCalledWith('setApplication', {id: 'abc123', data});
+          const committedData = context.commit.mock.calls[0][1].data;
           expect(committedData).not.toBe(data);
         });
       });


### PR DESCRIPTION
This PR fixes a bug which caused the Vuex module `application` to fail to correctly read & write documents in the Firestore `applications` collection.

The cause of this was that I'd incorrectly assumed that Vuex mutations could accept more than one parameter. In this case, we were passing 2 parameters to the `setApplication` mutation: `id` and `data`. However, as explained in the [online documentation][1], mutations only accept one payload parameter. The recommendation, therefore, is that an object is used as the payload to pass in more than one variable – which is exactly what I've done in this commit.

This failing was not highlighted in unit tests because the Vuex module is not actually loaded in to a Vuex store in the tests. Instead, individual methods and properties of the module are tested directly. This may well be something to improve upon at in the future, since in this case the tests were not mocking an equivalent API to that which Vuex expects.

[1]: https://vuex.vuejs.org/guide/mutations.html#commit-with-payload