### PR TITLE
Submit

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,25 +1,29 @@
 service cloud.firestore {
-  match /databases/{database}/documents {
-  	match /applicants/{userId} {
-    	// Users can read & write to their own applicant document
+    match /databases/{database}/documents {
+      match /applicants/{userId} {
+        // Users can read & write to their own applicant document
       allow get, create, update: if request.auth.uid == userId;
     }
 
     match /applications/{application} {
-    	function currentApplicant() {
-      	return path("/databases/" + database + "/documents/applicants/" + request.auth.uid);
+        function currentApplicant() {
+          return path("/databases/" + database + "/documents/applicants/" + request.auth.uid);
       }
 
       // Allow existing records which belong to the current user
-      allow get, list, update: if resource.data.applicant == currentApplicant();
+      allow get, list: if resource.data.applicant == currentApplicant();
 
       // Allow new records if they will belong to the current user
       allow create: if request.resource.data.applicant == currentApplicant();
+
+      allow update: if resource.data.applicant == currentApplicant() &&
+          resource.data.state != "submitted";
     }
 
     match /vacancies/{vacancy} {
-    	// Authenticated users can read
-    	allow get: if request.auth.uid != null;
+        // Authenticated users can read
+        allow get: if request.auth.uid != null;
     }
   }
 }
+

--- a/src/components/Review/BooleanWithCheckboxes.vue
+++ b/src/components/Review/BooleanWithCheckboxes.vue
@@ -57,7 +57,7 @@ export default {
   props: {
     answeredYes: Boolean,
     changeLink: String,
-    records: Object,
+    records: Array,
     subtitle: String,
     title: String,
     otherCaption: String,

--- a/src/components/Review/CharacterTable.vue
+++ b/src/components/Review/CharacterTable.vue
@@ -44,7 +44,7 @@
 export default {
   props: {
     answeredYes: Boolean,
-    records: Object,
+    records: Array,
     title: String
   },
   computed: {

--- a/src/router.js
+++ b/src/router.js
@@ -21,6 +21,7 @@ import Declarations from '@/views/Sections/Declarations/Edit';
 import Diversity from '@/views/Sections/Diversity/Edit';
 import Outreach from '@/views/Sections/Outreach/Edit';
 import Review from '@/views/Sections/Review/Edit';
+import Submitted from '@/views/Sections/Submitted/Show';
 
 Vue.use(Router);
 
@@ -85,6 +86,10 @@ const router = new Router({
         {
           path: 'review',
           component: Review,
+        },
+        {
+          path: 'submitted',
+          component: Submitted,
         },
       ],
     },

--- a/src/store/application.js
+++ b/src/store/application.js
@@ -27,7 +27,7 @@ const module = {
         .get();
 
       if (results.empty) {
-        commit('setApplication', {id: null, data: {}});
+        commit('setApplication', {id: null, data: { state: 'draft', createdAt: new Date, updatedAt: new Date}});
       } else {
         const doc = results.docs[0];
 
@@ -35,6 +35,7 @@ const module = {
         delete data.applicant;
         delete data.vacancy;
         data = sanitizeFirestore(data);
+        data.updatedAt = new Date;
 
         commit('setApplication', {id: doc.id, data});
       }

--- a/src/store/navigation.js
+++ b/src/store/navigation.js
@@ -53,6 +53,10 @@ const module = {
         title: 'Review and Submit',
         path: '/apply/review',
       },
+      {
+        title: 'Submitted',
+        path: '/apply/submitted',
+      },
     ],
     currentPage: undefined,
   },

--- a/src/views/Sections/Review/Edit.vue
+++ b/src/views/Sections/Review/Edit.vue
@@ -11,9 +11,9 @@
     <Preferences />
     <Declarations />
     <p>You are applying for <strong>{{vacancy.jac_ref}}: {{vacancy.title}}</strong></p>
-    <form @submit.prevent="saveAndSubmit">
+    <form @submit.prevent="save">
       <div class="form-actions">
-        <button class="btn btn-primary mr-2" type="button" @click.prevent="save">
+        <button class="btn btn-primary mr-2" type="button" @click.prevent="saveAndSubmit">
           Submit application
         </button>
         <span class="spinner-border spinner-border-sm text-secondary" v-if="isSaving"></span>
@@ -53,6 +53,10 @@ export default {
   },
   methods: {
     async saveAndSubmit() {
+      await this.save();
+      this.$emit('continue');
+    },
+    async save() {
       this.isSaving = true;
       this.application.state = 'submitted';
       await this.$store.dispatch('saveApplication', this.application);

--- a/src/views/Sections/Review/Edit.vue
+++ b/src/views/Sections/Review/Edit.vue
@@ -10,6 +10,15 @@
     <Character />
     <Preferences />
     <Declarations />
+    <p>You are applying for <strong>{{vacancy.jac_ref}}: {{vacancy.title}}</strong></p>
+    <form @submit.prevent="saveAndSubmit">
+      <div class="form-actions">
+        <button class="btn btn-primary mr-2" type="button" @click.prevent="save">
+          Submit application
+        </button>
+        <span class="spinner-border spinner-border-sm text-secondary" v-if="isSaving"></span>
+      </div>
+    </form>
   </section>
 </template>
 
@@ -38,7 +47,17 @@ export default {
   data() {
     return {
       vacancy: this.$store.getters.vacancy,
+      application: this.$store.getters.application(),
+      isSaving: false,
     };
   },
+  methods: {
+    async saveAndSubmit() {
+      this.isSaving = true;
+      this.application.state = 'submitted';
+      await this.$store.dispatch('saveApplication', this.application);
+      this.isSaving = false;
+    },
+  }
 }
 </script>

--- a/src/views/Sections/SelfAssessment/Edit.vue
+++ b/src/views/Sections/SelfAssessment/Edit.vue
@@ -3,7 +3,7 @@
     <form @submit.prevent="save">
       <h2>Your self assessment</h2>
 
-      <fieldset>
+      <fieldset :disabled="application.state === 'submitted'">
         <legend>Additional Selection Criteria</legend>
         <div class="form-group">
           <label for="additional_selection_criteria">How do you meet this requirement?</label>
@@ -11,13 +11,13 @@
         </div>
       </fieldset>
 
-      <fieldset>
+      <fieldset :disabled="application.state === 'submitted'">
         <legend>Authorisations</legend>
         <p>Do you currently have a Section 9(1) authorisation?</p>
         <BooleanInput v-model="application.has_section_9_1_authorisation" />
       </fieldset>
 
-      <fieldset>
+      <fieldset :disabled="application.state === 'submitted'">
         <legend>Self Assessment</legend>
         <div class="fieldset-text">
           You may wish to refer to our guidance and the competency framework for this exercise before you complete this part of your application.
@@ -44,7 +44,7 @@
         </div>
       </fieldset>
 
-      <SaveAndContinueButtons :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
+      <SaveAndContinueButtons v-if="application.state !== 'submitted'" :isSaving="isSaving" @saveAndContinue="saveAndContinue" />
     </form>
   </section>
 </template>

--- a/src/views/Sections/SelfAssessment/Edit.vue
+++ b/src/views/Sections/SelfAssessment/Edit.vue
@@ -3,6 +3,18 @@
     <form @submit.prevent="save">
       <h2>Your self assessment</h2>
 
+      <div class="card mb-3" v-if="application.state === 'submitted'">
+        <div class="card-header">
+          <h2 class="card-title">
+            You have submitted your application for this vacancy
+          </h2>
+        </div>
+        <div class="card-body">
+          Email dcj128@judicialappointments.gov.uk or call 020 3334 0123 to
+          discuss changes to your application.
+        </div>
+      </div>
+
       <fieldset :disabled="application.state === 'submitted'">
         <legend>Additional Selection Criteria</legend>
         <div class="form-group">
@@ -50,30 +62,30 @@
 </template>
 
 <script>
-  import BooleanInput from '@/components/BooleanInput';
-  import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
+import BooleanInput from '@/components/BooleanInput';
+import SaveAndContinueButtons from '@/components/SaveAndContinueButtons';
 
-  export default {
-    components: {
-      SaveAndContinueButtons,
-      BooleanInput,
+export default {
+  components: {
+    SaveAndContinueButtons,
+    BooleanInput,
+  },
+  data() {
+    return {
+      application: this.$store.getters.application(),
+      isSaving: false,
+    };
+  },
+  methods: {
+    async saveAndContinue() {
+      await this.save();
+      this.$emit('continue');
     },
-    data() {
-      return {
-        application: this.$store.getters.application(),
-        isSaving: false,
-      };
+    async save() {
+      this.isSaving = true;
+      await this.$store.dispatch('saveApplication', this.application);
+      this.isSaving = false;
     },
-    methods: {
-      async saveAndContinue() {
-        await this.save();
-        this.$emit('continue');
-      },
-      async save() {
-        this.isSaving = true;
-        await this.$store.dispatch('saveApplication', this.application);
-        this.isSaving = false;
-      },
-    }
   }
+}
 </script>

--- a/src/views/Sections/Submitted/Show.vue
+++ b/src/views/Sections/Submitted/Show.vue
@@ -1,0 +1,41 @@
+<template>
+  <section>
+    <article class="card" v-if="application.state === 'submitted'">
+      <div class="card-header">
+        <h2 class="card-title">
+          Thank you for your application
+        </h2>
+      </div>
+      <div class="card-body">
+        You have applied for <strong>{{vacancy.jac_ref}}: {{vacancy.title}}</strong>
+      </div>
+    </article>
+    <article class="card" v-else>
+      <div class="card-header">
+        <h2 class="card-title">
+          Please submit your application
+        </h2>
+      </div>
+      <div class="card-body">
+        <p>
+          You are applying for <strong>{{vacancy.jac_ref}}: {{vacancy.title}}</strong>
+        </p>
+        <p>
+          Your application is not complete until you have reviewed and submitted. Please do so on
+          the <router-link :to="'Review'">Review and Submit</router-link> page.
+        </p>
+      </div>
+    </article>
+  </section>
+</template>
+<script>
+
+export default {
+  data() {
+    return {
+      vacancy: this.$store.getters.vacancy,
+      application: this.$store.getters.application(),
+    };
+  }
+}
+</script>

--- a/tests/unit/store/application.spec.js
+++ b/tests/unit/store/application.spec.js
@@ -59,8 +59,8 @@ describe('store/application', () => {
 
       describe('application already exists in Firestore', () => {
         const docId = 'abc123';
-        const data = {status: 'draft'};
-        const sanitizedData = {status: 'draft', sanitized: true};
+        const data = {state: 'draft'};
+        const sanitizedData = {state: 'draft', sanitized: true, updatedAt: expect.any(Date)};
 
         beforeEach(async () => {
           getters.applicantDoc = 'applicants/4jsbvO27RJYqSRsgZM9sPhDFLDU2';
@@ -103,7 +103,14 @@ describe('store/application', () => {
         });
 
         it('commits a null document ID and an empty data object', () => {
-          expect(context.commit).toHaveBeenCalledWith('setApplication', {id: null, data: {}});
+          expect(context.commit)
+            .toHaveBeenCalledWith(
+              'setApplication',
+              {
+                id: null,
+                data: { createdAt: expect.any(Date), state: 'draft', updatedAt: expect.any(Date) }
+              }
+            );
         });
       });
 


### PR DESCRIPTION
This completes the user workflow for application submission.  

I decided to lock only the `SelfAssessment` record.  My thinking around this is that we will use a firestore function to snapshot all submitted data into a versioned record in a different, fully denormalised table, upon submit (`/SubmittedApplications` for example).  This would allow the users to update/edit personal details without affecting our working records.  

See my notes in the commits about timestamps and copy for the 'submitted' notification(s). 

