### PR TITLE
Add Firebase Hosting configuration for references

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -2,5 +2,17 @@
   "projects": {
     "default": "application-form-e08c9",
     "staging": "jac-application-form-staging"
+  },
+  "targets": {
+    "application-form-e08c9": {
+      "hosting": {
+        "apply": [
+          "application-form-e08c9"
+        ],
+        "reference": [
+          "jac-references"
+        ]
+      }
+    }
   }
 }

--- a/firebase.json
+++ b/firebase.json
@@ -3,21 +3,33 @@
     "rules": "firestore.rules",
     "indexes": "firestore.indexes.json"
   },
-  "hosting": {
-    "predeploy": "npm run build",
-    "public": "dist",
-    "ignore": [
-      "firebase.json",
-      "**/.*",
-      "**/node_modules/**"
-    ],
-    "rewrites": [
-      {
-        "source": "**",
-        "destination": "/index.html"
-      }
-    ]
-  },
+  "hosting": [
+    {
+      "target": "apply",
+      "predeploy": "npm run build",
+      "public": "dist",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ],
+      "rewrites": [
+        {
+          "source": "**",
+          "destination": "/index.html"
+        }
+      ]
+    },
+    {
+      "target": "reference",
+      "public": "reference",
+      "ignore": [
+        "firebase.json",
+        "**/.*",
+        "**/node_modules/**"
+      ]
+    }
+  ],
   "functions": {
     "predeploy": [
       "npm --prefix \"$RESOURCE_DIR\" run lint"

--- a/reference/index.html
+++ b/reference/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width,initial-scale=1.0">
+  <title>Provide a reference - Judical Appointments Commission</title>
+</head>
+<body>
+  <!-- nothing here yet -->
+</body>
+</html>


### PR DESCRIPTION
This PR configures Firebase to deploy to a second Hosting site called `jac-references`.
The new site is contained within the same Firebase project, but will likely have a URL of https://reference.judicialappointments.digital, and will be used by referees (independent assessors) to upload their reference documents.

The reference site probably won't have a build process or use any transpiling, so I've just created a new directory `reference` in the project to contain the files for that deployment. Eventually if we do end up needing to turn this into a more complex application, we may need to consider namespacing our frontend code into separate directories (e.g. top level `apply` and `reference` folders).

Firebase deployments will now deploy to both Hosting sites from their respective directories. To only deploy one site, specify the target at deploy time:

```
firebase deploy --only hosting:reference
```

or

```
firebase deploy --only hosting:apply
```

More information on hosting multiple sites can be found in the Firebase docs: https://firebase.google.com/docs/hosting/multisites#deploy_or_serve-locally