### PR TITLE
Send reference request emails

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -81,3 +81,23 @@ exports.processReferenceUpload = functions.storage
     }
     return true;
   });
+
+exports.sendReferenceRequestEmail = functions.firestore
+  .document('references/{referenceId}')
+  .onCreate((snapshot) => {
+    const config = functions.config();
+    const templateId = config.notify.templates.reference_request;
+    const data = snapshot.data();
+
+    const downloadUrl = `${config.references.url}/download-form/128.docx`;
+    const uploadUrl = `${config.references.url}/?ref=${snapshot.id}`;
+
+    const personalisation = {
+      'applicant name': data.applicant_name,
+      'assessor name': data.assessor.name,
+      'download url': downloadUrl,
+      'upload url': uploadUrl,
+    };
+
+    return sendEmail(data.assessor.email, templateId, personalisation);
+  });

--- a/functions/src/references/moveToGoogleDrive.js
+++ b/functions/src/references/moveToGoogleDrive.js
@@ -27,7 +27,7 @@ const uploadToGoogleDrive = async (object, reference, localPath) => {
   const applicantFolder = await folder.getOrCreate(referenceData.applicant_name, vacancyFolder);
 
   const ext = getFileExtension(object.name);
-  const fileName = `${referenceData.referee_name} (${referenceData.referee_type}).${ext}`;
+  const fileName = `${referenceData.assessor.name} (${referenceData.type}).${ext}`;
 
   const fileMetadata = {
     name: fileName,


### PR DESCRIPTION
This commit adds a function to send reference (independent assessment) request emails. The function is triggered automatically when new documents are created in the `references` collection.

The expected schema of a reference document is:

```json
{
  "applicant_name": "John Smith",
  "application": "XXX",
  "assessor": {
    "email": "assessor@example.com",
    "name": "Jane Doe",
    "phone": "01234567890",
    "position": "XXX",
    "relationship": "XXX"
  },
  "type": "Judicial",
  "state": "pending",
  "vacancy_title": "Title of the vacancy",
  "vacancy": "XXX"
}
```

This format is slightly different from what was expected when the `processReferenceUpload` function was developed. Therefore, I've also adjusted that function to use the new schema.

---

Closes #115 