### PR TITLE
Rename 'reference' to 'independent assessment'

### DIFF
--- a/reference/index.html
+++ b/reference/index.html
@@ -35,12 +35,12 @@
       </section>
 
       <section id="screen-upload" hidden>
-        <h1>Supply your reference</h1>
+        <h1>Supply your independent assessment</h1>
         <p>
           <strong id="applicant_name"></strong>
           has applied for the role
           <strong id="vacancy_title"></strong>
-          and has requested a reference from you.
+          and has requested an assessment from you.
         </p>
 
         <form onsubmit="event.preventDefault(); processForm();">
@@ -61,8 +61,8 @@
       </section>
 
       <section id="screen-received" hidden>
-        <h1>Reference received</h1>
-        <p>Thank you for uploading your reference.</p>
+        <h1>Independent assessment received</h1>
+        <p>Thank you for uploading your assessment.</p>
       </section>
 
       <section id="screen-not-found" hidden>


### PR DESCRIPTION
Throughout copy on the upload page, it has been requested that all use of the word 'reference' is changed to 'independent assessment'.