### PR TITLE
A script to export pending references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,4 @@ dist/
 
 # Report/export files
 functions/submitted.json
+functions/pendingReferences.csv

--- a/functions/exportPendingReferences.js
+++ b/functions/exportPendingReferences.js
@@ -1,0 +1,67 @@
+/*
+ *
+ * To run:
+ *
+ * ```
+ * export GOOGLE_CLOUD_PROJECT=application-form-e08c9
+ * cd functions
+ * node exportPendingReferences.js
+ * ```
+ *
+ * Export a CSV file of pending references.
+ *
+ * The CSV is formatted to be compatible with the GOV.UK Notify template used for sending out
+ * Independent Assessment request emails.
+ *
+ */
+const admin = require('firebase-admin');
+admin.initializeApp();
+const firestore = admin.firestore();
+const createCsvWriter = require('csv-writer').createArrayCsvWriter;
+
+const exportPath = 'pendingReferences.csv';
+
+const csvWriter = createCsvWriter({
+  header: [
+    'email address',
+    'applicant name',
+    'assessor name',
+    'download url',
+    'upload url',
+  ],
+  path: exportPath,
+});
+
+const getReferences = async (vacancyRef) => {
+  const references = await firestore.collection('references')
+    .where('vacancy', '==', vacancyRef)
+    .where('state', '==', 'pending')
+    .get();
+  return references.docs;
+};
+
+const generateCsvData = (references) => {
+  return references.map((reference) => {
+    const data = reference.data();
+    return [
+      data.assessor.email,
+      data.applicant_name,
+      data.assessor.name,
+      'https://reference.judicialappointments.digital/download-form/128.docx', // hardcoded for now
+      `https://reference.judicialappointments.digital/?ref=${reference.id}`,
+    ];
+  });
+};
+
+const main = async () => {
+  const vacancyId = 'hsQqdvAfZpSw94X2B8nA'; // hardcoded for now
+  const vacancyRef = firestore.collection('vacancies').doc(vacancyId);
+
+  const references = await getReferences(vacancyRef);
+  const data = generateCsvData(references);
+
+  await csvWriter.writeRecords(data);
+  console.log(`Exported CSV to ${exportPath}`);
+};
+
+main();

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -1629,6 +1629,12 @@
         "cssom": "0.3.x"
       }
     },
+    "csv-writer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/csv-writer/-/csv-writer-1.2.0.tgz",
+      "integrity": "sha512-ZU7eZ26y7oIOXwFHhTNnT/tF6RXMdQnuTGofzNTe1cvXacZm3Ixd7Oa9mOp2f1t39Ezfzg0h5tqfOjXM180BOg==",
+      "dev": true
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -26,6 +26,7 @@
     "request": "^2.88.0"
   },
   "devDependencies": {
+    "csv-writer": "^1.2.0",
     "eslint": "^5.12.0",
     "eslint-plugin-promise": "^3.6.0",
     "jest": "^24.7.1"


### PR DESCRIPTION
This script will create a CSV file of the pending references.

This contains columns which are compatible with the GOV.UK Notify personalisation fields, so a CSV produced by this script can be used (for example) to send reminder emails to assessors.

### Example output

| email address | applicant name | assessor name | download url | upload url |
| --- | --- | --- | --- | --- |
| assessor@example.com | John Smith | Jane Doe | https://reference.judicialappointments.digital/template.docx | https://reference.judicialappointments.digital/?ref=abc123 |