### PR TITLE
Enable function to create/update QT summary records based on submissions.

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2,6 +2,7 @@ const admin = require("firebase-admin");
 const functions = require("firebase-functions");
 const NotifyClient = require("notifications-node-client").NotifyClient;
 const qtSubmission = require("./qt/submission");
+exports.writeQtSummary = require("./qt/summary");
 
 admin.initializeApp();
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,7 +1,7 @@
 const admin = require("firebase-admin");
 const functions = require("firebase-functions");
 const NotifyClient = require("notifications-node-client").NotifyClient;
-const qtSubmission = require("./qt/submission");
+exports.qtSubmissions = require("./qt/submission");
 exports.writeQtSummary = require("./qt/summary");
 
 admin.initializeApp();
@@ -103,14 +103,3 @@ exports.sendReferenceRequestEmail = functions.firestore
 
     return sendEmail(data.assessor.email, templateId, personalisation);
   });
-
-exports.qtSubmissions = functions.https.onRequest((request, response) => {
-  qtSubmission.createRecord(request.body)
-    .then(() => {
-      return response.status(200).send({status: 'OK'});
-    })
-    .catch((e) => {
-      console.error(e);
-      return response.status(500).send({status: 'Error'});
-    });
-});

--- a/functions/qt/submission.js
+++ b/functions/qt/submission.js
@@ -43,7 +43,7 @@ const createRecord = async (record) => {
 }
 
 exports = module.exports = functions.https.onRequest((request, response) => {
-  createRecord(request.body)
+  return createRecord(request.body)
     .then(() => {
       return response.status(200).send({status: 'OK'});
     })

--- a/functions/qt/submission.js
+++ b/functions/qt/submission.js
@@ -8,8 +8,8 @@ const createRecord = async (record) => {
   console.info({ createRecordCalled: record });
 
   // This function expects the test title to be in the following format:
-  // "Optional Disambiguator (i.e. '128' or 'April 2019'): Test Name (i.e. RUCA): Test Phase (i.e. Situational Judgement)"
-  const titleFormat = /^[^:]*:?\s*([^:]+):\s*([^:]+)$/;
+  // Test Name (i.e. April 2019 RUCA): Test Phase (i.e. Situational Judgement)"
+  const titleFormat = /^(.+)\s*:\s*([^:]+)$/;
   testDetails = record.title.match(titleFormat);
   if (testDetails === null) {
     throw new Error("Title is incorrectly formatted " + record.title);
@@ -42,7 +42,7 @@ const createRecord = async (record) => {
   return true;
 }
 
-exports = module.exports = functions.https.onRequest((request, response) => {
+module.exports = functions.https.onRequest((request, response) => {
   return createRecord(request.body)
     .then(() => {
       return response.status(200).send({status: 'OK'});

--- a/functions/qt/submission.js
+++ b/functions/qt/submission.js
@@ -1,8 +1,9 @@
 const admin = require("firebase-admin");
+const functions = require("firebase-functions");
 
 // This throws exceptions rather than logging because we want to know as soon as these issues occur.  By throwing, we are
 // ensuring they will appear in StackDriver Errors in an actionable way.
-exports.createRecord = async (record) => {
+const createRecord = async (record) => {
   const firestore = admin.firestore();
   console.info({ createRecordCalled: record });
 
@@ -40,4 +41,15 @@ exports.createRecord = async (record) => {
 
   return true;
 }
+
+exports = module.exports = functions.https.onRequest((request, response) => {
+  createRecord(request.body)
+    .then(() => {
+      return response.status(200).send({status: 'OK'});
+    })
+    .catch((e) => {
+      console.error(e);
+      return response.status(500).send({status: 'Error'});
+    });
+});
 

--- a/functions/qt/summary.js
+++ b/functions/qt/summary.js
@@ -1,0 +1,23 @@
+const admin = require("firebase-admin");
+const functions = require("firebase-functions");
+
+exports = module.exports = functions.firestore.document("qtSubmissions/{submission}").onCreate((snapshot, context) => {
+  const firestore = admin.firestore();
+  const data = snapshot.data();
+  const record = {
+    [data.testName] :
+    { [data.testPhase] :
+      {
+        finishedAt: data.createdAt
+      }
+    }
+  };
+
+  return firestore
+    .collection("qtSummaries")
+    .doc(data.userId)
+    .set(record)
+    .then(() => console.info(record))
+    .catch(e => console.error({error: e, record}));
+});
+

--- a/functions/qt/summary.js
+++ b/functions/qt/summary.js
@@ -1,7 +1,7 @@
 const admin = require("firebase-admin");
 const functions = require("firebase-functions");
 
-exports = module.exports = functions.firestore.document("qtSubmissions/{submission}").onCreate((snapshot, context) => {
+module.exports = functions.firestore.document("qtSubmissions/{submission}").onCreate((snapshot, context) => {
   const firestore = admin.firestore();
   const data = snapshot.data();
   const record = {
@@ -16,7 +16,7 @@ exports = module.exports = functions.firestore.document("qtSubmissions/{submissi
   return firestore
     .collection("qtSummaries")
     .doc(data.userId)
-    .set(record)
+    .update(record)
     .then(() => console.info(record))
     .catch(e => console.error({error: e, record}));
 });


### PR DESCRIPTION
closes https://trello.com/c/OPlBbemx/15-as-a-jac-admin-i-want-each-test-phase-to-be-timed-on-submission

This includes the following commit: 

```
Reorganise QT functions

This is an intermediate step towards something like this:

https://codeburst.io/organizing-your-firebase-cloud-functions-67dc17b3b0da

I considered doing a full refactor to achieve an automated layout as
described in this article, but ultimately decided that doing so was
premature optimisation. I will probably reconsider this as I add more
functions, so this should not be taken to be the final layout of our
functions.
```