### PR TITLE
Format exported application dates as YYYY-MM-DD

### DIFF
--- a/functions/exportSubmitted.js
+++ b/functions/exportSubmitted.js
@@ -68,6 +68,24 @@ const getRecords = async () => {
   return records;
 };
 
+// Monkey patch the Date.toJSON method to adjust format in output
+// I'm sure there will be a cleaner way to do this, but using this as a quick & dirty solution
+// Dates will be formatted YYYY-MM-DD
+Date.prototype.toJSON = function() {
+  const pad = (number) => {
+    if (number < 10) {
+      return '0' + number;
+    }
+    return number;
+  };
+
+  const day = pad(this.getUTCDate());
+  const month = pad(this.getUTCMonth()+1);
+  const year = this.getUTCFullYear();
+
+  return year + '-' + month + '-' + day;
+};
+
 const main = async () => {
   const records = await getRecords();
   const output = JSON.stringify(records, null, 2);


### PR DESCRIPTION
This commit changes the script `functions/exportSubmitted.js`, which is used to produce a JSON file containing data of submitted applications, so that dates are formatted as YYYY-MM-DD.

To do this, it monkey patches the `toJSON` method on `Date` objects so that the `JSON.stringify()` method (which is used to produce the JSON export file) renders them in the desired format.

This is a hacky approach, but it works as intended in this context and was done under time pressure. It should be replaced with something more sensible in the future.