### PR TITLE
Open QT form in the same window

### DIFF
--- a/hosting/qt/src/components/TestPhase.vue
+++ b/hosting/qt/src/components/TestPhase.vue
@@ -101,7 +101,7 @@
         this.openForm();
       },
       openForm() {
-        window.open(this.formUrl);
+        window.location.href = this.formUrl;
       },
     },
   }


### PR DESCRIPTION
This commit changes the 'start test' button behaviour to open the Google Form in the same window, rather than in a new tab.

Early findings from usability testing show that opening the Google Form in a new tab hurts usability – it can be stopped by popup blockers, plus it doesn't support the idea that this is a linear user journey.