### PR TITLE
Add Sentry error tracking to the Qualifying Tests Vue application

### DIFF
--- a/hosting/qt/package-lock.json
+++ b/hosting/qt/package-lock.json
@@ -1496,6 +1496,73 @@
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
+    "@sentry/browser": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.4.0.tgz",
+      "integrity": "sha512-lsGJqryHXrnWRkdahnep0m+m65zyMJGCmB2T8pGS+SFcSXdx94TaK4PiPaCl6XUCT5ejuQUHoXsEBmK/3S6beA==",
+      "requires": {
+        "@sentry/core": "5.4.0",
+        "@sentry/types": "5.4.0",
+        "@sentry/utils": "5.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.4.0.tgz",
+      "integrity": "sha512-luIJPftVnrW0ZKqs9W6YCpzKZVbOgQv8Ae7KB0Acsvqeoqjtx4zHHfVfu5VPkfhrOYN3NsM1IpApXtSdMiJCfg==",
+      "requires": {
+        "@sentry/hub": "5.4.0",
+        "@sentry/minimal": "5.4.0",
+        "@sentry/types": "5.4.0",
+        "@sentry/utils": "5.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.4.0.tgz",
+      "integrity": "sha512-X0iLNcouXcLWzuOJz2YjTn1E11b7pzcG98/iFTHW3AKPjnJNt92XRpjsDI2iT8+ODUDiFqaFmACSn2oZK80WGQ==",
+      "requires": {
+        "@sentry/types": "5.4.0",
+        "@sentry/utils": "5.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/integrations": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-5.4.0.tgz",
+      "integrity": "sha512-8jnO7Rac+qdhiRGhtFy0znmAjaT9OI88Z5rrQVAjfJArTgDQ7YmqAFlR0603IMC0PGItMdQcZth/1XjCKfjQqw==",
+      "requires": {
+        "@sentry/types": "5.4.0",
+        "@sentry/utils": "5.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.4.0.tgz",
+      "integrity": "sha512-MuOLavHHTXXWKyfTcwqpjhkdYlJDyOfjfcf+b/d38+8cs064rpNScxTZyYj2KKxNGcCqDgUsY175fNp/D1fyMw==",
+      "requires": {
+        "@sentry/hub": "5.4.0",
+        "@sentry/types": "5.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.4.0.tgz",
+      "integrity": "sha512-R8IFM77rzp0ngR/XQFLsXUK2uE7jLf21MsU9mpUwLtxcJp8rs7I77HgzA5MEerdG9Sbxw5RaLq9wO7noHGfUmQ=="
+    },
+    "@sentry/utils": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.4.0.tgz",
+      "integrity": "sha512-NlYMAyiI9iIItLDxJ17tLMtuu7261t93tcOGSMdDQZlmryR6ZAMenbCKTf5MrpA2iHfX84gyfmr67lh8uSHkPg==",
+      "requires": {
+        "@sentry/types": "5.4.0",
+        "tslib": "^1.9.3"
+      }
+    },
     "@soda/friendly-errors-webpack-plugin": {
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@soda/friendly-errors-webpack-plugin/-/friendly-errors-webpack-plugin-1.7.1.tgz",

--- a/hosting/qt/package.json
+++ b/hosting/qt/package.json
@@ -9,6 +9,8 @@
     "test": "vue-cli-service test:unit"
   },
   "dependencies": {
+    "@sentry/browser": "^5.4.0",
+    "@sentry/integrations": "^5.4.0",
     "bootstrap": "^4.3.1",
     "core-js": "^2.6.9",
     "deepmerge": "^3.2.0",

--- a/hosting/qt/src/main.js
+++ b/hosting/qt/src/main.js
@@ -3,9 +3,6 @@ import Router from 'vue-router';
 import Vuex from 'vuex';
 import App from '@/App.vue';
 import {auth} from '@/firebase';
-import {initSentry} from '@/sentry';
-
-initSentry();
 
 Vue.config.productionTip = false;
 Vue.use(Router);
@@ -13,6 +10,9 @@ Vue.use(Vuex);
 
 const router = require('@/router').default;
 const store = require('@/store').default;
+
+const sentry = require('@/sentry');
+sentry.initSentry();
 
 // Initialise the Vue app once Firebase Auth has initialised
 // The Vue app depends on the user's auth state to load the correct view (i.e. an authenticated view or the login view)

--- a/hosting/qt/src/main.js
+++ b/hosting/qt/src/main.js
@@ -3,6 +3,9 @@ import Router from 'vue-router';
 import Vuex from 'vuex';
 import App from '@/App.vue';
 import {auth} from '@/firebase';
+import {initSentry} from '@/sentry';
+
+initSentry();
 
 Vue.config.productionTip = false;
 Vue.use(Router);

--- a/hosting/qt/src/sentry.js
+++ b/hosting/qt/src/sentry.js
@@ -1,12 +1,26 @@
 import Vue from 'vue';
 import * as Sentry from '@sentry/browser';
 import * as Integrations from '@sentry/integrations';
+import store from '@/store';
 
 const initSentry = () => {
   Sentry.init({
     dsn: 'https://2ae111f2a62d4f7bbe84aaf868f0f0d5@sentry.io/1472344',
     integrations: [new Integrations.Vue({Vue, attachProps: true})],
   });
+  setUserScope();
 };
+
+const setUserScope = () => {
+  Sentry.configureScope((scope) => {
+    scope.setUser({
+      id: store.getters.currentUserId,
+      email: store.getters.currentUserEmail,
+    });
+  });
+};
+
+// Update the Sentry user scope when the current user changes in the Vuex store
+store.watch((state, getters) => (getters.currentUserId), setUserScope);
 
 export {initSentry};

--- a/hosting/qt/src/sentry.js
+++ b/hosting/qt/src/sentry.js
@@ -6,6 +6,7 @@ import store from '@/store';
 const initSentry = () => {
   Sentry.init({
     dsn: 'https://2ae111f2a62d4f7bbe84aaf868f0f0d5@sentry.io/1472344',
+    environment: process.env.NODE_ENV,
     integrations: [new Integrations.Vue({Vue, attachProps: true})],
   });
   setUserScope();

--- a/hosting/qt/src/sentry.js
+++ b/hosting/qt/src/sentry.js
@@ -1,0 +1,12 @@
+import Vue from 'vue';
+import * as Sentry from '@sentry/browser';
+import * as Integrations from '@sentry/integrations';
+
+const initSentry = () => {
+  Sentry.init({
+    dsn: 'https://2ae111f2a62d4f7bbe84aaf868f0f0d5@sentry.io/1472344',
+    integrations: [new Integrations.Vue({Vue, attachProps: true})],
+  });
+};
+
+export {initSentry};

--- a/hosting/qt/src/views/TakeTest.vue
+++ b/hosting/qt/src/views/TakeTest.vue
@@ -60,8 +60,9 @@
             this.loaded = true;
             this.$store.dispatch('subscribeQtSummary');
           })
-          .catch(() => {
+          .catch((e) => {
             this.loadFailed = true;
+            throw e;
           });
       },
     },


### PR DESCRIPTION
This pull request adds Sentry error tracking to the QT Vue app at https://qt.judicialappointments.digital

This is currently configured to log to a free Sentry account which I've set up. If we choose to go ahead and use this in production, we should probably upgrade this account so that it can be shared with team members. But for now, the free plan is sufficient.

One nice integration feature is that it'll track the user ID and email address of the currently authenticated user. Therefore we'll have a view of how many, and which, users have been affected by errors out in the wild.

In particular, I'm interested to see exceptions from the 'Take Test' load process being logged. This is where we observed problems during usability testing. In order to log to Sentry, I've `throw`n the caught exception, so it 'bubbles up' as an unhandled exception. That way it'll be picked up by Sentry.