### PR TITLE
Don't use Sentry in development environment

### DIFF
--- a/hosting/qt/src/main.js
+++ b/hosting/qt/src/main.js
@@ -11,8 +11,13 @@ Vue.use(Vuex);
 const router = require('@/router').default;
 const store = require('@/store').default;
 
-const sentry = require('@/sentry');
-sentry.initSentry();
+if (process.env.NODE_ENV !== 'development') {
+  // Don't use Sentry in development
+  // We want to see Vue & JS errors in the local developer console rather than being silently rerouted to Sentry
+  // Related GitHub issues: https://github.com/getsentry/sentry-javascript/issues/1416 https://github.com/vuejs/vue/issues/8433
+  const sentry = require('@/sentry');
+  sentry.initSentry();
+}
 
 // Initialise the Vue app once Firebase Auth has initialised
 // The Vue app depends on the user's auth state to load the correct view (i.e. an authenticated view or the login view)


### PR DESCRIPTION
When Sentry is enabled, Vue and JS error messages are not logged to the local developer JS console.

It's more useful to see these error messages in the console during development, rather than having them silenced and rerouted to Sentry.

This PR disables Sentry when Vue is running in a development environment. Sentry remains enabled for test and production environments.

Related GitHub issues:
- https://github.com/getsentry/sentry-javascript/issues/1416
- https://github.com/vuejs/vue/issues/8433