### PR TITLE
Update Firestore security rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -20,7 +20,7 @@ service cloud.firestore {
       // Allow new records if they will belong to the current user
       allow create: if request.resource.data.applicant == currentApplicant();
 
-      // Allow updates on records which belong, and will continue to belonging, to the current user
+      // Allow updates on records which belong, and will continue to belong, to the current user
       // But only if the application isn't in a 'submitted' state
       allow update: if resource.data.applicant == currentApplicant() &&
                        request.resource.data.applicant == currentApplicant() &&
@@ -62,7 +62,7 @@ service cloud.firestore {
       allow create: if userIsAuthenticated() &&
                        belongsToCurrentUser(request.resource);
 
-      // Allow updates on records which belong, and will continue to belonging, to the current user
+      // Allow updates on records which belong, and will continue to belong, to the current user
       allow update: if userIsAuthenticated() &&
                        belongsToCurrentUser(resource) &&
                        belongsToCurrentUser(request.resource);

--- a/firestore.rules
+++ b/firestore.rules
@@ -26,7 +26,7 @@ service cloud.firestore {
 
     match /vacancies/{vacancy} {
       // Authenticated users can read
-      allow get: if request.auth.uid != null;
+      allow get: if userIsAuthenticated();
     }
 
     match /references/{reference} {
@@ -37,7 +37,7 @@ service cloud.firestore {
 
     match /tests/{test} {
       // Authenticated users can read
-      allow get: if request.auth.uid != null;
+      allow get: if userIsAuthenticated();
     }
 
     match /usersTests/{userTest} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,4 +1,8 @@
 service cloud.firestore {
+  function userIsAuthenticated() {
+    return request.auth.uid != null;
+  }
+
   match /databases/{database}/documents {
     match /applicants/{userId} {
       // Users can read & write to their own applicant document
@@ -41,14 +45,23 @@ service cloud.firestore {
         return res.data.userUid == request.auth.uid;
       }
 
+      function doesNotExist() {
+        return resource == null;
+      }
+
       // Allow read on records which belong to the current user
-      allow get, list: if belongsToCurrentUser(resource);
+      // Also allow reads to documents which don't yet exist – so our client-side app can
+      // listen for changes on documents it hasn't created yet
+      allow get, list: if userIsAuthenticated() &&
+                          (belongsToCurrentUser(resource) || doesNotExist());
 
       // Allow new records if they will belong to the current user
-      allow create: if belongsToCurrentUser(request.resource);
+      allow create: if userIsAuthenticated() &&
+                       belongsToCurrentUser(request.resource);
 
       // Allow updates on records which belong, and will continue to belonging, to the current user
-      allow update: if belongsToCurrentUser(resource) &&
+      allow update: if userIsAuthenticated() &&
+                       belongsToCurrentUser(resource) &&
                        belongsToCurrentUser(request.resource);
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,8 +20,11 @@ service cloud.firestore {
       // Allow new records if they will belong to the current user
       allow create: if request.resource.data.applicant == currentApplicant();
 
+      // Allow updates on records which belong, and will continue to belonging, to the current user
+      // But only if the application isn't in a 'submitted' state
       allow update: if resource.data.applicant == currentApplicant() &&
-          resource.data.state != "submitted";
+                       request.resource.data.applicant == currentApplicant() &&
+                       resource.data.state != "submitted";
     }
 
     match /vacancies/{vacancy} {


### PR DESCRIPTION
This PR resolves a Firestore permissions error which was triggered by the QT Vue application. The specifics of this are documented in the message for commit 1774f00.

Additionally, as part of some general housekeeping / tech debt clean up, it tightens the existing security rules around updates to documents in the `applications` collection. More details in the message for commit dc8416f.

Closes [Trello card 92](https://trello.com/c/AWf81tlk/92-error-insufficient-permissions-when-subscribing-to-a-userstests-document-which-doesnt-exist-yet).