### PR TITLE
Collect the user's name at sign up

### DIFF
--- a/hosting/qt/src/components/FirebaseUI.vue
+++ b/hosting/qt/src/components/FirebaseUI.vue
@@ -21,7 +21,7 @@
           signInOptions: [
             {
               provider: auth.EmailAuthProvider.PROVIDER_ID,
-              requireDisplayName: false
+              requireDisplayName: true
             }
           ],
           credentialHelper: firebaseui.auth.CredentialHelper.NONE,
@@ -33,7 +33,7 @@
     },
     methods: {
       signInSuccess(authResult) {
-          this.$emit('signInSuccess', authResult);
+        this.$emit('signInSuccess', authResult);
         // Return false to disable FirebaseUI auth redirect
         return false;
       },

--- a/hosting/qt/tests/unit/components/FirebaseUI.spec.js
+++ b/hosting/qt/tests/unit/components/FirebaseUI.spec.js
@@ -66,7 +66,7 @@ describe('FirebaseUI component', () => {
       signInOptions: [
         {
           provider: auth.EmailAuthProvider.PROVIDER_ID,
-          requireDisplayName: false
+          requireDisplayName: true
         }
       ],
       credentialHelper: firebaseui.auth.CredentialHelper.NONE,


### PR DESCRIPTION
This commit enables the collection of user display names on the FirebaseUI sign up screen. This will be presented as an additional field at sign up with the label 'First & last name'.

We'll use the collected user names to personalise emails sent to them.

Additionally, I cleaned up some bad code indentation in the `signInSuccess` method.