### PR TITLE
Content changes for qualifying tests

### DIFF
--- a/hosting/qt/src/components/TestCard.vue
+++ b/hosting/qt/src/components/TestCard.vue
@@ -1,18 +1,24 @@
 <template>
-  <div class="card mb-3">
+  <div class="card">
     <div class="card-body">
-      <h5 class="card-title">
-        {{test.title}}
-        <small class="text-muted">– 50 minutes</small>
-      </h5>
+      <h5 class="card-title">{{test.title}}</h5>
 
-      <p>20 multiple choice questions</p>
+      <p>
+        There are 20 multiple choice questions of equal weight. Each question presents a hypothetical situation that you might
+        face in the tribunal role you’ve applied for.
+      </p>
+      <p>
+        In each situation there is an issue or problem you need to resolve, with 5 possible answers. You’ll need to tick a box
+        for the best and worst answer in each case. There are no marks for next best or next worst answer.
+      </p>
 
       <div v-if="testIsOpen">
+        <hr />
         <div class="custom-control custom-checkbox mb-3">
-          <input type="checkbox" id="terms_agreed" class="custom-control-input" v-model="termsAgreed" :disabled="userHasStartedTest">
-          <label for="terms_agreed" class="custom-control-label">
-            I confirm that I will keep this test confidential and not share the scenario or questions at any point during or after the selection exercise.
+          <input type="checkbox" id="terms" class="custom-control-input" v-model="termsAgreed" :disabled="userHasStartedTest">
+          <label for="terms" class="custom-control-label">
+            I confirm that I will keep this test confidential and not share the scenario or questions at any point during or after
+            the selection exercise.
           </label>
         </div>
 

--- a/hosting/qt/src/views/Login.vue
+++ b/hosting/qt/src/views/Login.vue
@@ -4,6 +4,7 @@
       <div class="text-center mb-3 mt-5">
         <img src="@/assets/jac-logo.svg" alt="Judicial Appointments Commission" width="197" height="66">
       </div>
+      <p>To take this test, set up an account with the email address you used for your application and then choose a password.</p>
       <FirebaseUI @signInSuccess="loginRedirect" />
     </div>
   </main>

--- a/hosting/qt/src/views/TakeTest.vue
+++ b/hosting/qt/src/views/TakeTest.vue
@@ -22,7 +22,23 @@
         <p>This test is open.</p>
       </div>
 
-      <TestCard v-if="!testHasClosed" />
+      <div v-if="!testHasClosed && !userHasFinishedTest">
+        <h5>Do’s and don’ts</h5>
+        <ul>
+          <li><strong>Do</strong> make sure you’ve got a stable internet connection before you start</li>
+          <li><strong>Don’t</strong> press the back button at any point</li>
+          <li><strong>Don’t</strong> close the test window until you’ve submitted your answers</li>
+        </ul>
+
+        <h5>Timing</h5>
+        <ul>
+          <li>You have <strong>45 minutes</strong> to complete the test and must manage the time yourself</li>
+          <li>Time starts when you click ‘start test’ and stops when you click ‘submit’</li>
+          <li>Your answers won’t be marked if you submit after 45 minutes</li>
+        </ul>
+      </div>
+
+      <TestCard v-if="!testHasClosed" class="mt-4" />
 
       <div v-if="testHasClosed">
         <p>This test has now closed.</p>
@@ -69,6 +85,7 @@
         'testIsOpen',
         'testHasOpened',
         'testHasClosed',
+        'userHasFinishedTest',
       ]),
     },
     mounted() {

--- a/hosting/qt/src/views/VerifyEmail.vue
+++ b/hosting/qt/src/views/VerifyEmail.vue
@@ -7,9 +7,9 @@
     <details>
       <summary>I haven’t got the email yet</summary>
       <section>
-        <p>It could take up to 10 minutes for the email to arrive.</p>
+        <p>It could take up to 2 minutes for the email to arrive.</p>
         <p>Check your ‘spam’ or ‘junk mail’ folder in case it didn’t go into your inbox.</p>
-        <p>If it still hasn’t arrived after 10 minutes, you can ask us to resend the email:</p>
+        <p>If it still hasn’t arrived after 2 minutes, click ‘resend email’:</p>
         <button class="btn btn-primary" type="button" :disabled="sendInProgress" @click.prevent="sendVerificationEmail">
           Resend email
         </button>


### PR DESCRIPTION
This PR implements content changes for the qualifying tests Vue application. These changes have been made based on user research findings, mostly in an attempt to better explain the qualifying test to users and help them through the journey.

This PR completes the 'Page content' checklist of [Trello card 90](https://trello.com/c/MMrZFxAa/90-content-updates-to-qt-app).

NB: There is one noted exception to the content changes. We still need to update the test window content (i.e. "This test is open.", "This test has closed.", etc.). This has been split out into [a separate Trello card](https://trello.com/c/DZoUPFET/105-make-test-opening-hours-dynamic).