### PR TITLE
Display the test date and opening/closing times

### DIFF
--- a/hosting/qt/jest.config.js
+++ b/hosting/qt/jest.config.js
@@ -27,5 +27,6 @@ module.exports = {
   coverageReporters: [
     'html',
     'text-summary'
-  ]
-}
+  ],
+  setupTestFrameworkScriptFile: 'jest-extended',
+};

--- a/hosting/qt/package-lock.json
+++ b/hosting/qt/package-lock.json
@@ -9736,6 +9736,46 @@
         "jest-util": "^23.4.0"
       }
     },
+    "jest-extended": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/jest-extended/-/jest-extended-0.11.1.tgz",
+      "integrity": "sha512-4klauyMgaoqMG27yu2HMGoQLVJ5ntJuJRgUKA/HS0oiGNBuSOkXNB7dxDtL83qYaBDMLVaOjy23QPLXFASUbVg==",
+      "dev": true,
+      "requires": {
+        "expect": "^23.6.0",
+        "jest-get-type": "^22.4.3",
+        "jest-matcher-utils": "^22.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "jest-matcher-utils": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-22.4.3.tgz",
+          "integrity": "sha512-lsEHVaTnKzdAPR5t4B6OcxXo9Vy4K+kRRbG5gtddY8lBEC+Mlpvm1CJcsMESRjzUhzkz568exMV1hTB76nAKbA==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1",
+            "jest-get-type": "^22.4.3",
+            "pretty-format": "^22.4.3"
+          }
+        },
+        "pretty-format": {
+          "version": "22.4.3",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-22.4.3.tgz",
+          "integrity": "sha512-S4oT9/sT6MN7/3COoOy+ZJeA92VmOnveLHgrwBE3Z1W5N9S2A1QGNYiE1z75DAENbJrXXUb+OWXhpJcg05QKQQ==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0",
+            "ansi-styles": "^3.2.0"
+          }
+        }
+      }
+    },
     "jest-get-type": {
       "version": "22.4.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",

--- a/hosting/qt/package-lock.json
+++ b/hosting/qt/package-lock.json
@@ -5112,6 +5112,11 @@
       "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
       "dev": true
     },
+    "dayjs": {
+      "version": "1.8.14",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.14.tgz",
+      "integrity": "sha512-AVhDmRTe541iWirnoeFSSDDGvCT6HWaNQ4z2WmmzXMGZj6ph6ydao2teKq/eUtR43GPJXlYFD+C/SotG1P9wUQ=="
+    },
     "de-indent": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",

--- a/hosting/qt/package.json
+++ b/hosting/qt/package.json
@@ -13,6 +13,7 @@
     "@sentry/integrations": "^5.4.0",
     "bootstrap": "^4.3.1",
     "core-js": "^2.6.9",
+    "dayjs": "^1.8.14",
     "deepmerge": "^3.2.0",
     "firebase": "^6.1.0",
     "firebaseui": "^4.0.0",

--- a/hosting/qt/package.json
+++ b/hosting/qt/package.json
@@ -31,6 +31,7 @@
     "babel-jest": "^23.6.0",
     "eslint": "^5.8.0",
     "eslint-plugin-vue": "^5.0.0",
+    "jest-extended": "^0.11.1",
     "jest-serializer-vue": "^2.0.2",
     "node-sass": "^4.12.0",
     "sass-loader": "^7.1.0",
@@ -50,11 +51,6 @@
     "parserOptions": {
       "parser": "babel-eslint"
     }
-  },
-  "jest": {
-    "snapshotSerializers": [
-      "jest-serializer-vue"
-    ]
   },
   "postcss": {
     "plugins": {

--- a/hosting/qt/src/components/TestWindow.vue
+++ b/hosting/qt/src/components/TestWindow.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    <p v-if="beforeTestDay">
+      The test window will be open on {{testDate}} {{timeWindow}}.
+    </p>
+
+    <p v-if="isTestDay && !testHasOpened">
+      The test window will be open today {{timeWindow}}.
+    </p>
+
+    <template v-if="testIsOpen">
+      <p>
+        The test window is now open and closes at {{formatTime(closingTime)}}.
+      </p>
+      <p>
+        Start the test no later than {{formatTime(closingTime.subtract(1, 'hour'))}}
+        to give yourself time to complete it before the window closes.
+      </p>
+    </template>
+
+    <p v-if="isTestDay && testHasClosed">
+      This test has closed. The test window was today {{timeWindow}}.
+    </p>
+
+    <p v-if="afterTestDay">
+      This test has closed. The test window was {{testDate}} {{timeWindow}}.
+    </p>
+  </div>
+</template>
+
+<script>
+  import { mapGetters } from 'vuex';
+  import dayjs from 'dayjs';
+
+  export default {
+    computed: {
+      ...mapGetters([
+        'test',
+        'testHasOpened',
+        'testHasClosed',
+        'testIsOpen',
+      ]),
+      openingTime() {
+        return dayjs(this.test.openingTime);
+      },
+      closingTime() {
+        return dayjs(this.test.closingTime);
+      },
+      now() {
+        return dayjs();
+      },
+      beforeTestDay() {
+        return this.now.isBefore(this.openingTime, 'day');
+      },
+      isTestDay() {
+        return this.now.isSame(this.openingTime, 'day');
+      },
+      afterTestDay() {
+        return this.now.isAfter(this.openingTime, 'day');
+      },
+      testDate() {
+        return this.formatDate(this.openingTime);
+      },
+      timeWindow() {
+        const openingTime = this.formatTime(this.openingTime);
+        const closingTime = this.formatTime(this.closingTime);
+        return `between ${openingTime} and ${closingTime}`;
+      }
+    },
+    methods: {
+      formatDate(date) {
+        return date.format('D MMMM YYYY');
+      },
+      formatTime(date) {
+        return date.format('ha');
+      },
+    },
+  }
+</script>

--- a/hosting/qt/src/views/TakeTest.vue
+++ b/hosting/qt/src/views/TakeTest.vue
@@ -14,13 +14,7 @@
     <div ref="qtView" v-if="loaded === true">
       <h4>{{test.vacancyTitle}}</h4>
 
-      <div v-if="!testHasOpened">
-        <p>This test will be open on 23 June 2019 between 7am and 9pm.</p>
-      </div>
-
-      <div v-if="testIsOpen">
-        <p>This test is open.</p>
-      </div>
+      <TestWindow />
 
       <div v-if="!testHasClosed && !userHasFinishedTest">
         <h5>Do’s and don’ts</h5>
@@ -39,10 +33,6 @@
       </div>
 
       <TestCard v-if="!testHasClosed" class="mt-4" />
-
-      <div v-if="testHasClosed">
-        <p>This test has now closed.</p>
-      </div>
     </div>
   </main>
 </template>
@@ -50,10 +40,12 @@
 <script>
   import { mapGetters } from 'vuex';
   import TestCard from '@/components/TestCard';
+  import TestWindow from '@/components/TestWindow';
 
   export default {
     components: {
       TestCard,
+      TestWindow,
     },
     data() {
       return {
@@ -82,8 +74,6 @@
     computed: {
       ...mapGetters([
         'test',
-        'testIsOpen',
-        'testHasOpened',
         'testHasClosed',
         'userHasFinishedTest',
       ]),

--- a/hosting/qt/tests/unit/components/TestWindow.spec.js
+++ b/hosting/qt/tests/unit/components/TestWindow.spec.js
@@ -1,0 +1,105 @@
+import {shallowMount, createLocalVue} from '@vue/test-utils';
+import Vuex from 'vuex';
+import TestWindow from '@/components/TestWindow';
+
+const localVue = createLocalVue();
+localVue.use(Vuex);
+
+describe('components/TestWindow', () => {
+  const createTestSubject = (mockGetters) => {
+    const defaultMockGetters = {
+      test: () => ({
+        openingTime: new Date(),
+        closingTime: new Date(),
+      }),
+      testHasOpened: () => false,
+      testHasClosed: () => false,
+      testIsOpen:    () => false,
+    };
+    const store = new Vuex.Store({
+      getters: {
+        ...defaultMockGetters,
+        ...mockGetters
+      },
+    });
+    return shallowMount(TestWindow, {localVue, store});
+  };
+
+  let subject;
+
+  it('renders in a HTML <div> tag', () => {
+    subject = createTestSubject({});
+    expect(subject.is('div')).toBe(true);
+  });
+
+  describe('before test day', () => {
+    beforeEach(() => {
+      const mockGetters = {
+        test: () => ({
+          openingTime: new Date('2050-06-17 07:00:00'),
+          closingTime: new Date('2050-06-17 21:00:00'),
+        }),
+        testHasOpened: () => false,
+        testHasClosed: () => false,
+        testIsOpen:    () => false,
+      };
+      subject = createTestSubject(mockGetters);
+    });
+
+    it('starts with "The test window will be open on"', () => {
+      expect(subject.text()).toStartWith('The test window will be open on');
+    });
+
+    it('shows the date of the test', () => {
+      expect(subject.text()).toContain('17 June 2050');
+    });
+
+    it('shows the opening and closing times', () => {
+      expect(subject.text()).toContain('between 7am and 9pm');
+    });
+  });
+
+  describe('on test day', () => {
+    describe('before the test window has opened', () => {
+      // TODO: Impement tests
+      it.skip('', () => {});
+    });
+
+    describe('when the test window is open', () => {
+      // TODO: Impement tests
+      it.skip('', () => {});
+    });
+
+    describe('after the test window has closed', () => {
+      // TODO: Impement tests
+      it.skip('', () => {});
+    });
+  });
+
+  describe('after test day', () => {
+    beforeEach(() => {
+      const mockGetters = {
+        test: () => ({
+          openingTime: new Date('2000-02-05 09:00:00'),
+          closingTime: new Date('2000-02-05 17:00:00'),
+        }),
+        testHasOpened: () => true,
+        testHasClosed: () => true,
+        testIsOpen:    () => false,
+      };
+      subject = createTestSubject(mockGetters);
+    });
+
+    it('starts with "This test has closed."', () => {
+      expect(subject.text()).toStartWith('This test has closed.');
+    });
+
+    it('shows the date of the test', () => {
+      expect(subject.text()).toContain('5 February 2000');
+    });
+
+    it('shows the opening and closing times', () => {
+      expect(subject.text()).toContain('between 9am and 5pm');
+    });
+  });
+});


### PR DESCRIPTION
This PR implements dynamic date & time display for a qualifying test. Previously the test date & time was hardcoded – this makes it dynamic, to match the `openingTime` and `closingTime` values from the database.

As part of this implementation, I've created a new `TimeWindow` component which is used to display this content. This allows us to simplify the `TakeTest` page component, which previously performed a similar function.

Tests are partially implemented for the `TestWindow` component. They still need to be added to, but for now we need to merge this in to meet our **20 June** launch date.