### PR TITLE
Show a warning to Internet Explorer users

### DIFF
--- a/hosting/qt/src/components/IEWarning.vue
+++ b/hosting/qt/src/components/IEWarning.vue
@@ -1,0 +1,19 @@
+<template>
+  <div v-if="isIE" class="alert alert-danger mt-5 mb-5" role="alert">
+    <h4>Warning</h4>
+    <p><strong>You’re using Internet Explorer.</strong></p>
+    <p>The test will not work correctly on this browser – use Chrome, Firefox or Microsoft Edge instead.</p>
+  </div>
+</template>
+
+<script>
+  export default {
+    data() {
+      return {
+        // Detect whether we're in Internet Explorer by checking for the existence of `document.documentMode`
+        // `document.documentMode` is only present in IE. For every other browser it's undefined.
+        isIE: !!document.documentMode,
+      };
+    }
+  }
+</script>

--- a/hosting/qt/src/main.scss
+++ b/hosting/qt/src/main.scss
@@ -33,6 +33,7 @@ $custom-control-label-disabled-color: $body-color;
 @import "../node_modules/bootstrap/scss/utilities";
 @import "../node_modules/bootstrap/scss/forms";
 @import "../node_modules/bootstrap/scss/custom-forms";
+@import "../node_modules/bootstrap/scss/alert";
 
 // Import project SCSS
 @import "scss/details";

--- a/hosting/qt/src/views/Login.vue
+++ b/hosting/qt/src/views/Login.vue
@@ -4,6 +4,7 @@
       <div class="text-center mb-3 mt-5">
         <img src="@/assets/jac-logo.svg" alt="Judicial Appointments Commission" width="197" height="66">
       </div>
+      <IEWarning />
       <p>To take this test, set up an account with the email address you used for your application and then choose a password.</p>
       <FirebaseUI @signInSuccess="loginRedirect" />
     </div>
@@ -12,10 +13,12 @@
 
 <script>
   import FirebaseUI from '@/components/FirebaseUI';
+  import IEWarning from '@/components/IEWarning';
 
   export default {
     components: {
       FirebaseUI,
+      IEWarning,
     },
     methods: {
       loginRedirect(authResult) {

--- a/hosting/qt/src/views/TakeTest.vue
+++ b/hosting/qt/src/views/TakeTest.vue
@@ -2,6 +2,8 @@
   <main class="container">
     <h1>Take a qualifying test</h1>
 
+    <IEWarning />
+
     <div ref="loadingMessage" v-if="loaded === false && loadFailed === false">
       <span class="spinner-border spinner-border-sm text-secondary" aria-hidden="true"></span>
       Loading...
@@ -41,11 +43,13 @@
   import { mapGetters } from 'vuex';
   import TestCard from '@/components/TestCard';
   import TestWindow from '@/components/TestWindow';
+  import IEWarning from '@/components/IEWarning';
 
   export default {
     components: {
       TestCard,
       TestWindow,
+      IEWarning,
     },
     data() {
       return {


### PR DESCRIPTION
This adds a warning message to the 'sign in' and 'take test' pages for users browsing in Internet Explorer. Whilst the Vue application works in Internet Explorer, we know that Google Forms has problems which result in a poor user experience.

Users will still be able to proceed with taking a test on Internet Explorer, but we're hoping that the warning message will be a sufficient deterrent.