### PR TITLE
Hardcode the test ID for the next QT

### DIFF
--- a/hosting/qt/src/router.js
+++ b/hosting/qt/src/router.js
@@ -51,7 +51,7 @@ const router = new Router({
     },
     {
       path: '*',
-      redirect: '/take-test/open',
+      redirect: '/take-test/Q3QPebYC4it3Orp4RtA7',
     },
   ],
   scrollBehavior(to, from, savedPosition) {

--- a/hosting/qt/tests/unit/journeys/signin.spec.js
+++ b/hosting/qt/tests/unit/journeys/signin.spec.js
@@ -56,9 +56,9 @@ describe('Sign in journey', () => {
     });
 
     describe('when I visit /', () => {
-      it('redirects to /take-test/open', () => {
+      it('redirects to /take-test/Q3QPebYC4it3Orp4RtA7', () => {
         router.push('/');
-        expect(subject.vm.$route.path).toBe('/take-test/open');
+        expect(subject.vm.$route.path).toBe('/take-test/Q3QPebYC4it3Orp4RtA7');
       });
     });
   });


### PR DESCRIPTION
We don't have a 'list QTs' page for users to choose a qualifying test. Therefore, until we do, we simply auto-redirect them to the correct test. This is hardcoded in the router.

I've set the router to automatically direct people to the test with ID `Q3QPebYC4it3Orp4RtA7`. We'll use this for the next test.