### PR TITLE
Fix a bug with `sanitizeFirestore` utility function

### DIFF
--- a/hosting/apply/src/utils/sanitizeFirestore.js
+++ b/hosting/apply/src/utils/sanitizeFirestore.js
@@ -19,7 +19,7 @@ import {Timestamp} from "@/firebase";
 
 const reviver = (key, value) => {
   // Convert serialized Timestamp objects to Date objects
-  if (typeof value == 'object' && typeof value.seconds == 'number' && typeof value.nanoseconds == 'number') {
+  if (value && typeof value == 'object' && typeof value.seconds == 'number' && typeof value.nanoseconds == 'number') {
     value = new Timestamp(value.seconds, value.nanoseconds).toDate();
   }
   return value;

--- a/hosting/apply/tests/unit/utils/sanitizeFirestore.spec.js
+++ b/hosting/apply/tests/unit/utils/sanitizeFirestore.spec.js
@@ -56,6 +56,7 @@ describe('utils/sanitizeFirestore', () => {
       ],
       qt_passed: true,
       qt_score: 28,
+      a_null_value: null,
     };
 
     const sanitized = sanitizeFirestore(data);
@@ -71,6 +72,7 @@ describe('utils/sanitizeFirestore', () => {
     ]);
     expect(sanitized.qt_passed).toEqual(true);
     expect(sanitized.qt_score).toEqual(28);
+    expect(sanitized.a_null_value).toBeNull();
   });
 
   it("doesn't change the input object (when passed by reference)", () => {
@@ -84,6 +86,18 @@ describe('utils/sanitizeFirestore', () => {
     sanitizeFirestore(data);
 
     expect(data.applied_date).toBe(timestamp);
+  });
+
+  it('returns a new object', () => {
+    const data = {
+      name: 'John Smith',
+      email: 'johnsmith@example.com',
+    };
+
+    const sanitized = sanitizeFirestore(data);
+
+    expect(sanitized).toEqual(data);
+    expect(sanitized).not.toBe(data);
   });
 
   const falsy = [null, undefined, false];

--- a/hosting/qt/src/utils/sanitizeFirestore.js
+++ b/hosting/qt/src/utils/sanitizeFirestore.js
@@ -19,7 +19,7 @@ import {Timestamp} from "@/firebase";
 
 const reviver = (key, value) => {
   // Convert serialized Timestamp objects to Date objects
-  if (typeof value == 'object' && typeof value.seconds == 'number' && typeof value.nanoseconds == 'number') {
+  if (value && typeof value == 'object' && typeof value.seconds == 'number' && typeof value.nanoseconds == 'number') {
     value = new Timestamp(value.seconds, value.nanoseconds).toDate();
   }
   return value;

--- a/hosting/qt/tests/unit/utils/sanitizeFirestore.spec.js
+++ b/hosting/qt/tests/unit/utils/sanitizeFirestore.spec.js
@@ -56,6 +56,7 @@ describe('utils/sanitizeFirestore', () => {
       ],
       qt_passed: true,
       qt_score: 28,
+      a_null_value: null,
     };
 
     const sanitized = sanitizeFirestore(data);
@@ -71,6 +72,7 @@ describe('utils/sanitizeFirestore', () => {
     ]);
     expect(sanitized.qt_passed).toEqual(true);
     expect(sanitized.qt_score).toEqual(28);
+    expect(sanitized.a_null_value).toBeNull();
   });
 
   it("doesn't change the input object (when passed by reference)", () => {
@@ -84,6 +86,18 @@ describe('utils/sanitizeFirestore', () => {
     sanitizeFirestore(data);
 
     expect(data.applied_date).toBe(timestamp);
+  });
+
+  it('returns a new object', () => {
+    const data = {
+      name: 'John Smith',
+      email: 'johnsmith@example.com',
+    };
+
+    const sanitized = sanitizeFirestore(data);
+
+    expect(sanitized).toEqual(data);
+    expect(sanitized).not.toBe(data);
   });
 
   const falsy = [null, undefined, false];


### PR DESCRIPTION
There was an error with `sanitizeFirestore` where it'd throw an exception when it encountered a `null` field value.

Due to a quirk in the way the JavaScript type system works, `null` has a type of `object`. Despite this, `null` does not *behave* like an `object`. Any attempt to access properties of `null` – e.g. `variable.property` where `variable = null` results in an exception.

Due to the above, the `sanitizeFirestore` utility function was incorrectly attempting to access `.seconds` and `.nanoseconds` properties when it encountered a `null` value, since it was treating it as a regular object.

This fixes that so that `null` values pass through untouched. Only *actual* objects are inspected.

--- 

Also I've added a test for a previously untested feature of `sanitizeFirestore`, which is that it will always return a *new* object.