### PR TITLE
Record the start time of qualifying tests using the server time

### DIFF
--- a/hosting/qt/package-lock.json
+++ b/hosting/qt/package-lock.json
@@ -5155,11 +5155,6 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
-    "deepmerge": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
-      "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow=="
-    },
     "default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",

--- a/hosting/qt/package.json
+++ b/hosting/qt/package.json
@@ -14,7 +14,6 @@
     "bootstrap": "^4.3.1",
     "core-js": "^2.6.9",
     "dayjs": "^1.8.14",
-    "deepmerge": "^3.2.0",
     "firebase": "^6.1.0",
     "firebaseui": "^4.0.0",
     "vue": "^2.6.6",

--- a/hosting/qt/src/firebase.js
+++ b/hosting/qt/src/firebase.js
@@ -23,3 +23,4 @@ const functions = firebase.functions;
 const Timestamp = firebase.firestore.Timestamp;
 
 export {firestore, auth, functions, Timestamp};
+export default firebase;


### PR DESCRIPTION
Rather than relying on the clock on the end user's device.

This is possible thanks to Firestore's `serverTimestamp` feature. It allows us to have Firestore populate the `startedAt` field of a `userTest` document with a timestamp generated server-side, which is important because it acts as a known and trusted source of truth for the current time. The end user's device is less likely to have a reliable 'true' time.

Plus, since we'll also write the `finishedAt` field using `serverTimestamp`, it means we'll be using the same clock to record both the start and finish times of a user's test.